### PR TITLE
Add a feature to specify the externally exposed Heimdall port

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,4 @@ heimdall_container_labels: []
 
 # The public port for the Heimdall server
 heimdall_public_port: 443
+heimdall_insecure_public_port: 80

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,3 +32,6 @@ heimdall_network_name: ""
 
 # Labels to put on the application containers
 heimdall_container_labels: []
+
+# The public port for the Heimdall server
+heimdall_public_port: 443

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -12,8 +12,9 @@ services:
 {% endif %}
     restart: always
     ports:
-      - target: 443
-        published: "{{ heimdall_public_port }}"
+      - "{{ heimdall_public_port }}:443"
+      # - target: 443
+      #   published: "{{ heimdall_public_port }}"
 {% if heimdall_network_name %}
     networks:
       - {{ heimdall_network_name }}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -12,7 +12,8 @@ services:
 {% endif %}
     restart: always
     ports:
-      - "443"
+      - target: 443
+        published: "{{ heimdall_public_port }}"
 {% if heimdall_network_name %}
     networks:
       - {{ heimdall_network_name }}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -13,6 +13,7 @@ services:
     restart: always
     ports:
       - "{{ heimdall_public_port }}:443"
+      - "127.0.0.1:{{ heimdall_insecure_public_port}}:80"
       # - target: 443
       #   published: "{{ heimdall_public_port }}"
 {% if heimdall_network_name %}


### PR DESCRIPTION
I'd like to be able to explicitly set the public port for my Heimdall instance, instead of getting whatever Docker gives me.